### PR TITLE
Click to Expand Text

### DIFF
--- a/WVWebsite/app/static/main.css
+++ b/WVWebsite/app/static/main.css
@@ -20,7 +20,8 @@
   font-size: 3rem;
 }
 
-.post-header {
+.post-header>p {
+  display: inline-block;
   margin-bottom: 0rem;
 }
 
@@ -52,4 +53,16 @@ img.icon-image {
   border-radius: 50%;
   max-height: 50px;
   border: #99e0f7 solid 1px;
+}
+
+.ellipsis {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chevron-up {
+  background-color: lightgray;
 }

--- a/WVWebsite/app/templates/base.html
+++ b/WVWebsite/app/templates/base.html
@@ -65,7 +65,7 @@
       <div>
         <p class="text-center">
           | Logged user: {{ user.username }} | Email: {{ user.email }} |
-          Admin:{{ user.is_superuser }} | <a  href="{% url 'logout' %}">Sign Out</a>
+          Admin:{{ user.is_superuser }} | <a href="{% url 'logout' %}">Sign Out</a>
         </p>
       </div>
       {% endif %}
@@ -127,7 +127,7 @@
         console.log($('#header-img').css('background-size'));
       } else {
         $('#header-img').css('background-size', '100% auto').css('background-position',
-          'center -10%');;
+          'center -50%');;
       }
     }
 

--- a/WVWebsite/app/templates/base.html
+++ b/WVWebsite/app/templates/base.html
@@ -69,6 +69,17 @@
         </p>
       </div>
       {% endif %}
+      <!-- Latest compiled and minified JavaScript -->
+      <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+      <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
+        integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous">
+      </script>
+      <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
+        integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous">
+      </script>
+      <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
+        integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous">
+      </script>
       {% block content %}{% endblock %}
     </div>
 
@@ -100,17 +111,6 @@
     </div>
   </div>
 
-  <!-- Latest compiled and minified JavaScript -->
-  <!-- jQuery first, then Popper.js, then Bootstrap JS -->
-  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
-    integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous">
-  </script>
-  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
-    integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous">
-  </script>
-  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
-    integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous">
-  </script>
   <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
   <script>
     tinymce.init({

--- a/WVWebsite/app/templates/home.html
+++ b/WVWebsite/app/templates/home.html
@@ -6,16 +6,16 @@
     <div class="row mt-2">
         <div class="col-md-5">
             <div class="p-2">
-                    {% for about in abouts  %}
-                        {{about.content|safe}}
-                        {% if user.is_superuser %}
-                       <a href="{% url 'update_about' about.pk %}" class="col-md-2 pull-right">
-                            <button type="button" class="btn btn-primary btn-block">Update</button>
-                        </a>
-                      {% endif %}
+                {% for about in abouts  %}
+                {{about.content|safe}}
+                {% if user.is_superuser %}
+                <a href="{% url 'update_about' about.pk %}" class="col-md-2 pull-right">
+                    <button type="button" class="btn btn-primary btn-block">Update</button>
+                </a>
+                {% endif %}
 
-                    {% endfor %}
-                    
+                {% endfor %}
+
             </div>
         </div>
         <div class="col-md-3">
@@ -49,14 +49,17 @@
 <div class="posts p-4">
     <h3>Community Updates</h3>
     {% for post in posts %}
-    <div class="card my-1">
+    <div class="card my-1 update-box">
         <div class="card-body">
-            <h5 class="post-header">{{post.title|safe}}</h5>
+            <h5 class="post-header border-bottom d-flex justify-content-between chevron-down p-1 rounded">
+                {{post.title|safe}}<span class="ml-auto chevron">&#x25BC;</span></h5>
             <small class="mt-0 mb-1">
                 Created {{ post.pub_date }} by {{ post.user }}
             </small>
-            <div>
-                {{ post.body|safe }}
+            <div class="post-body ellipsis">
+                <div>
+                    {{ post.body|safe }}
+                </div>
             </div>
             {% if user.is_superuser %}
             <div>
@@ -72,7 +75,38 @@
             {% endif %}
         </div>
     </div>
-
     {% endfor %}
 </div>
+
+<script>
+    function expandTextFromChevron() {
+        $(this).find('span.chevron').html('&#x25B2;');
+        $(this).parent().find('div.post-body').removeClass('ellipsis');
+        $(this).removeClass('chevron-down').addClass('chevron-up');
+        $('.chevron-up').click(collapseTextFromChevron);
+    }
+
+    $('.chevron-down').click(expandTextFromChevron);
+
+    function expandTextFromEllipsis() {
+        $(this).parent().find('.chevron-down').removeClass('chevron-down').addClass('chevron-up').find('span.chevron')
+            .html('&#x25B2;');
+        $(this).removeClass('ellipsis');
+        $('.chevron-up').click(collapseTextFromChevron);
+    }
+
+    $('.ellipsis').click(expandTextFromEllipsis);
+
+    function collapseTextFromChevron() {
+        console.log('hello?')
+        $(this).find('span.chevron').html('&#x25BC;');
+        $(this).parent().find('div.post-body').addClass('ellipsis');
+        $(this).removeClass('chevron-up').addClass('chevron-down');
+    }
+
+    $('.chevron-up').click(collapseTextFromChevron);
+</script>
+
+
+
 {% endblock content %}


### PR DESCRIPTION
Added a class to hide over-flow text. In Firefox, it shows a trailing ellipsis, but not so in Chrome. Clicking on hidden text will expand, and the header for the card will also expand AND collapse text. JS will definitely need a refactor, but it works!